### PR TITLE
enable trust proxy (cdn)

### DIFF
--- a/apps/cdn/src/app.ts
+++ b/apps/cdn/src/app.ts
@@ -11,6 +11,8 @@ const app = express();
 app.disable("etag");
 app.disable("x-powered-by");
 
+app.set("trust proxy", true);
+
 app.use(express.json());
 
 app.use("/avatar", avatar);


### PR DESCRIPTION
In order to get req.ip working, trust proxy must be set to true